### PR TITLE
0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - Put your changes here...
 
+## 0.1.5
+
+- fallback-dependencies will now detect if your clone is out of date in the case of `-b` versioned entries. If it's out of date, it will remove the old clone and re-clone it.
+- fallback-dependencies will no longer install devDependencies of a given repo.
+
 ## 0.1.4
 
 - You can now prevent a fallback-dependency from being installed in a situation where the repo is not a direct dependency of the root project by appending the `directOnly:` flag to the end of the dependency name.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fallback-dependencies",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fallback-dependencies",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "CC-BY-4.0",
       "dependencies": {
         "cross-env": "7.0.3"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/fallback-dependencies/graphs/contributors"
     }
   ],
-  "version": "0.1.4",
+  "version": "0.1.5",
   "files": [
     "fallback-dependencies.js"
   ],


### PR DESCRIPTION
- fallback-dependencies will now detect if your clone is out of date in the case of `-b` versioned entries. If it's out of date, it will remove the old clone and re-clone it.
- fallback-dependencies will no longer install devDependencies of a given repo.