### PR TITLE
0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Put your changes here...
 
+## 0.1.6
+
+- Backed out `--omit=dev` change from 0.1.5 that prevented fallback-dependencies from installing devDependencies of a given repo.
+
 ## 0.1.5
 
 - fallback-dependencies will now detect if your clone is out of date in the case of `-b` versioned entries. If it's out of date, it will remove the old clone and re-clone it.

--- a/fallback-dependencies.js
+++ b/fallback-dependencies.js
@@ -118,8 +118,8 @@ if (pkg.fallbackDependencies && (pkg.fallbackDependencies.repos || pkg.fallbackD
         })
         // do npm ci in the new dir only if package-lock exists and the don't install deps flag is not set
         if (fs.existsSync(fallbackDependenciesDir + '/' + dependency + '/package-lock.json') && !skipDeps) {
-          console.log('Running npm ci --omit=dev on ' + fallbackDependenciesDir + '/' + dependency + '...')
-          execSync('cross-env FALLBACK_DEPENDENCIES_INITIATED_COMMAND=true npm ci --omit=dev', {
+          console.log('Running npm ci on ' + fallbackDependenciesDir + '/' + dependency + '...')
+          execSync('cross-env FALLBACK_DEPENDENCIES_INITIATED_COMMAND=true npm ci', {
             stdio: [0, 1, 2], // display output from git
             cwd: path.resolve(fallbackDependenciesDir + '/' + dependency, '')
           })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fallback-dependencies",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fallback-dependencies",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "CC-BY-4.0",
       "dependencies": {
         "cross-env": "7.0.3"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/fallback-dependencies/graphs/contributors"
     }
   ],
-  "version": "0.1.5",
+  "version": "0.1.6",
   "files": [
     "fallback-dependencies.js"
   ],


### PR DESCRIPTION
- Backed out `--omit=dev` change from 0.1.5 that prevented fallback-dependencies from installing devDependencies of a given repo.