### PR TITLE
1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 1.1.3
 
 - Added option to enable checking out rather than recloning when changing versions via `FALLBACK_DEPENDENCIES_ENABLE_CHECKOUT` environment variable or `enableCheckout` in `fallbackDependencies` package.json config.
-- Updated tests.
 
 ## 1.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.3
+
+- Added option to enable checking out rather than recloning when changing versions via `FALLBACK_DEPENDENCIES_ENABLE_CHECKOUT` environment variable or `enableCheckout` in `fallbackDependencies` package.json config.
+- Updated tests.
+
 ## 1.1.2
 
 - Fixed `FALLBACK_DEPENDENCIES_RERUN_NPM_CI` / `rerunNpmCi` setting to only apply to dependencies that have not been updated.

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -29,3 +29,7 @@ To include additional arguments to pass to the `npm ci` command, set the environ
 ## Remove stale directories from dependency target folder
 
 To remove stale directories from the dependency target folder, set the environment variable `FALLBACK_DEPENDENCIES_REMOVE_STALE_DIRECTORIES` to `true` or set `removeStaleDirectories` in `fallbackDependencies` package.json config.
+
+## Enable checkout instead of default recloning for dependency versions
+
+By default, whenever the user changes the `-b` version of the repository to clone from, fallback-dependencies will perform a reclone instead of allowing a checkout. This behavior is optimized for users who prioritize disk space. However, for those who value convenience, setting the environment variable `FALLBACK_DEPENDENCIES_ENABLE_CHECKOUT` to `true` or setting `enableCheckout` in `fallbackDependencies` package.json config enables the ability to check out branches, commit IDs, and tags without the need to reclone the repository, as long as the provided URL matches that of the target directory.

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -29,7 +29,3 @@ To include additional arguments to pass to the `npm ci` command, set the environ
 ## Remove stale directories from dependency target folder
 
 To remove stale directories from the dependency target folder, set the environment variable `FALLBACK_DEPENDENCIES_REMOVE_STALE_DIRECTORIES` to `true` or set `removeStaleDirectories` in `fallbackDependencies` package.json config.
-
-## Enable checkout instead of default recloning for dependency versions
-
-By default, whenever the user changes the `-b` version of the repository to clone from, fallback-dependencies will perform a reclone instead of allowing a checkout. This behavior is optimized for users who prioritize disk space. However, for those who value convenience, setting the environment variable `FALLBACK_DEPENDENCIES_ENABLE_CHECKOUT` to `true` or setting `enableCheckout` in `fallbackDependencies` package.json config enables the ability to check out branches, commit IDs, and tags without the need to reclone the repository, as long as the provided URL matches that of the target directory.

--- a/USAGE.md
+++ b/USAGE.md
@@ -30,6 +30,7 @@ Next, add a `fallbackDependencies` entry to your `package.json` alongside your `
 - `npmCiArgs` *[String or Array of Strings]*: Additional arguments to pass to `npm ci` command. Default: `undefined`.
 - `removeStaleDirectories` *[Boolean]*: Removes stale directories from dependency target folder. Default: `false`.
 - `enableCheckout` *[Boolean]*: Enables the ability to check out branches, commit IDs, and tags without the need to reclone the repository, as long as the provided URL matches that of the target directory. Default: `false`.
+  - Choose `true` to optimize for disk space. Choose `false` to optimize for minimizing network activity.
 
 Example of `reposFile` usage:
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -29,6 +29,7 @@ Next, add a `fallbackDependencies` entry to your `package.json` alongside your `
 - `rerunNpmCi` *[Boolean]*: Option to run `npm ci` on clones even if they already exist. Default: `false`.
 - `npmCiArgs` *[String or Array of Strings]*: Additional arguments to pass to `npm ci` command. Default: `undefined`.
 - `removeStaleDirectories` *[Boolean]*: Removes stale directories from dependency target folder. Default: `false`.
+- `enableCheckout` *[Boolean]*: Enables the ability to check out branches, commit IDs, and tags without the need to reclone the repository, as long as the provided URL matches that of the target directory. Default: `false`.
 
 Example of `reposFile` usage:
 

--- a/fallback-dependencies.js
+++ b/fallback-dependencies.js
@@ -127,86 +127,82 @@ function executeFallbackList (listTypes) {
                     }
                   } else {
                     const parts = url.split(' ')
-                    if (parts.includes('-b')) {
-                      if (!parts.some(url => fs.readFileSync(fallbackDependenciesDir + '/' + dependency + '/.git/config', 'utf8').includes(url))) {
-                        logger.log('Removing ' + fallbackDependenciesDir + '/' + dependency + ' from ' + url + ' because a different git url was supplied. It will be re-cloned.')
-                        fs.rmSync(path.resolve(fallbackDependenciesDir + '/' + dependency, ''), { recursive: true, force: true })
-                        reClone = true
-                      } else {
-                        let version = ''
-                        for (const key in parts) {
-                          const part = parts[key]
-                          if (part === '-b') {
-                            version = parts[parseInt(key) + 1]
-                            break
-                          }
+                    if (parts.includes('-b') && fs.readFileSync(fallbackDependenciesDir + '/' + dependency + '/.git/config', 'utf8').includes(parts[0])) {
+                      let version = ''
+                      for (const key in parts) {
+                        const part = parts[key]
+                        if (part === '-b') {
+                          version = parts[parseInt(key) + 1]
+                          break
                         }
-                        const output = spawnSync('git', ['tag'], { // get list of tags
+                      }
+                      const output = spawnSync('git', ['tag'], { // get list of tags
+                        shell: false,
+                        cwd: path.resolve(fallbackDependenciesDir + '/' + dependency, '')
+                      })
+                      if (output.status !== 0) throw output.stderr.toString()
+                      if (output.stdout.toString().split('\n').includes(version)) { // version supplied is a valid tag
+                        const tag = spawnSync('git', ['describe', '--tags'], { // get nearest tag
                           shell: false,
                           cwd: path.resolve(fallbackDependenciesDir + '/' + dependency, '')
                         })
-                        if (output.status !== 0) throw output.stderr.toString()
-                        if (output.stdout.toString().split('\n').includes(version)) { // version supplied is a valid tag
-                          const tag = spawnSync('git', ['describe', '--tags'], { // get nearest tag
-                            shell: false,
-                            cwd: path.resolve(fallbackDependenciesDir + '/' + dependency, '')
-                          })
-                          if (tag.stdout.toString().trim() === version) { // up to date with supplied tag
-                            logger.log('Already up to date: ' + fallbackDependenciesDir + '/' + dependency + ' from ' + url + ' is already up to date because the commit\'s git tag matches the desired -b version number.')
-                            if (!rerunNpmCi) break // stop checking fallbacks
-                          } else { // version supplied is a valid tag, but differs from current tag
-                            const fetch = spawnSync('git', ['fetch', '--tags'], {
-                              shell: false,
-                              cwd: path.resolve(fallbackDependenciesDir + '/' + dependency, '')
-                            })
-                            if (fetch.status !== 0) throw fetch.stderr.toString()
-                            const checkout = spawnSync('git', ['checkout', version], {
-                              shell: false,
-                              cwd: path.resolve(fallbackDependenciesDir + '/' + dependency, '')
-                            })
-                            if (checkout.status !== 0) throw checkout.stderr.toString()
-                            logger.log(`Successfully checked out tag ${version}.`)
-                            updatedDep = true
-                          }
-                        } else { // version supplied is not a tag
-                          const remote = spawnSync('git', ['remote'], {
-                            shell: false,
-                            cwd: path.resolve(fallbackDependenciesDir + '/' + dependency, '')
-                          })
-                          const fetch = spawnSync('git', ['fetch', remote.stdout.toString().trim()], {
+                        if (tag.stdout.toString().trim() === version) { // up to date with supplied tag
+                          logger.log('Already up to date: ' + fallbackDependenciesDir + '/' + dependency + ' from ' + url + ' is already up to date because the commit\'s git tag matches the desired -b version number.')
+                          if (!rerunNpmCi) break // stop checking fallbacks
+                        } else { // version supplied is a valid tag, but differs from current tag
+                          const fetch = spawnSync('git', ['fetch', '--tags'], {
                             shell: false,
                             cwd: path.resolve(fallbackDependenciesDir + '/' + dependency, '')
                           })
                           if (fetch.status !== 0) throw fetch.stderr.toString()
-                          const commitsBehind = spawnSync('git', ['rev-list', '--count', `HEAD..${remote.stdout.toString().trim()}/${version}`], {
+                          const checkout = spawnSync('git', ['checkout', version], {
                             shell: false,
                             cwd: path.resolve(fallbackDependenciesDir + '/' + dependency, '')
                           })
-                          if (commitsBehind.status !== 0) {
-                            const checkout = spawnSync('git', ['checkout', version], {
-                              shell: false,
-                              cwd: path.resolve(fallbackDependenciesDir + '/' + dependency, '')
-                            })
-                            if (checkout.status !== 0) throw checkout.stderr.toString()
-                            logger.log(`Successfully checked out commit ${version}.`)
-                            updatedDep = true
-                          } else if (commitsBehind.stdout.toString() > 0) { // git pull if behind
-                            logger.log('There are new commits available.')
-                            logger.log('Running git pull on ' + fallbackDependenciesDir + '/' + dependency + '...')
-                            const pull = spawnSync('git', ['pull', remote.stdout.toString().trim(), version], {
-                              shell: false,
-                              cwd: path.resolve(fallbackDependenciesDir + '/' + dependency, '')
-                            })
-                            if (pull.status !== 0) throw pull.stderr.toString()
-                            updatedDep = true
-                          } else {
-                            logger.log('Already up to date: ' + fallbackDependenciesDir + '/' + dependency + ' from ' + url + ' is already up to date because the commit\'s branch name matches the desired -b branch name.')
-                            if (!rerunNpmCi) break // stop checking fallbacks
-                          }
+                          if (checkout.status !== 0) throw checkout.stderr.toString()
+                          logger.log(`Successfully checked out tag ${version}.`)
+                          updatedDep = true
+                        }
+                      } else { // version supplied is not a tag
+                        const remote = spawnSync('git', ['remote'], {
+                          shell: false,
+                          cwd: path.resolve(fallbackDependenciesDir + '/' + dependency, '')
+                        })
+                        const fetch = spawnSync('git', ['fetch', remote.stdout.toString().trim()], {
+                          shell: false,
+                          cwd: path.resolve(fallbackDependenciesDir + '/' + dependency, '')
+                        })
+                        if (fetch.status !== 0) throw fetch.stderr.toString()
+                        const commitsBehind = spawnSync('git', ['rev-list', '--count', `HEAD..${remote.stdout.toString().trim()}/${version}`], {
+                          shell: false,
+                          cwd: path.resolve(fallbackDependenciesDir + '/' + dependency, '')
+                        })
+                        if (commitsBehind.status !== 0) {
+                          const checkout = spawnSync('git', ['checkout', version], {
+                            shell: false,
+                            cwd: path.resolve(fallbackDependenciesDir + '/' + dependency, '')
+                          })
+                          if (checkout.status !== 0) throw checkout.stderr.toString()
+                          logger.log(`Successfully checked out commit ${version}.`)
+                          updatedDep = true
+                        } else if (commitsBehind.stdout.toString() > 0) { // git pull if behind
+                          logger.log('There are new commits available.')
+                          logger.log('Running git pull on ' + fallbackDependenciesDir + '/' + dependency + '...')
+                          const pull = spawnSync('git', ['pull', remote.stdout.toString().trim(), version], {
+                            shell: false,
+                            cwd: path.resolve(fallbackDependenciesDir + '/' + dependency, '')
+                          })
+                          if (pull.status !== 0) throw pull.stderr.toString()
+                          updatedDep = true
+                        } else {
+                          logger.log('Already up to date: ' + fallbackDependenciesDir + '/' + dependency + ' from ' + url + ' is already up to date because the commit\'s branch name matches the desired -b branch name.')
+                          if (!rerunNpmCi) break // stop checking fallbacks
                         }
                       }
                     } else {
-                      logger.error('Cannot update ' + fallbackDependenciesDir + '/' + dependency + ' from ' + url + ' because it appears to be a different git repo or from a different remote!')
+                      logger.log('Removing ' + fallbackDependenciesDir + '/' + dependency + ' from ' + url + ' because a different git url was supplied. It will be re-cloned.')
+                      fs.rmSync(path.resolve(fallbackDependenciesDir + '/' + dependency, ''), { recursive: true, force: true })
+                      reClone = true
                     }
                   }
                   if (!reClone && !rerunNpmCi && !updatedDep) continue // try the next fallback

--- a/fallback-dependencies.js
+++ b/fallback-dependencies.js
@@ -96,6 +96,7 @@ function executeFallbackList (listTypes) {
           for (const i in fallbacks) {
             let url = fallbacks[i]
             const rerunNpmCi = process.env.FALLBACK_DEPENDENCIES_RERUN_NPM_CI || pkg[listType].rerunNpmCi
+            const disableReClone = process.env.FALLBACK_DEPENDENCIES_DISABLE_RECLONE || pkg[listType].disableReClone
             let reClone = false
             let updatedDep = false
             let skipDeps = false
@@ -104,30 +105,31 @@ function executeFallbackList (listTypes) {
               skipDeps = true
             }
             try {
-              if (fs.existsSync(fallbackDependenciesDir + '/' + dependency)) {
+              if (fs.existsSync(fallbackDependenciesDir + '/' + dependency)) { // NOTE: repo dir already exists
                 if (!fs.existsSync(fallbackDependenciesDir + '/' + dependency + '/.git/config')) {
                   logger.error('Cannot update ' + fallbackDependenciesDir + '/' + dependency + ' because it does not appear to be a git repo!')
                   break // move on to next dep
                 } else {
-                  // scan .git/config to see if `url` exists within it
-                  if (fs.readFileSync(fallbackDependenciesDir + '/' + dependency + '/.git/config', 'utf8').search(url) > 0) {
-                    // update only if it's a direct match — same repo from the same place
-                    logger.log('Running git pull on ' + fallbackDependenciesDir + '/' + dependency + '...')
-                    try {
-                      const output = spawnSync('git', ['pull'], {
+                  const parts = url.split(' ')
+                  if (fs.readFileSync(fallbackDependenciesDir + '/' + dependency + '/.git/config', 'utf8').includes(parts[0])) { // scan .git/config to check if url supplied exists within it
+                    if (!parts.includes('-b') && disableReClone) { // TODO: add a `&&` for if env var is supplied. adds -b to bare url that points to HEAD
+                      const remote = spawnSync('git', ['remote'], {
                         shell: false,
-                        stdio: [0, 1, 2], // display output from git
                         cwd: path.resolve(fallbackDependenciesDir + '/' + dependency, '')
                       })
-                      if (output.status !== 0) throw output.stderr.toString()
-                      updatedDep = true
-                    } catch (e) {
-                      logger.error('Cannot update ' + fallbackDependenciesDir + '/' + dependency + ' from ' + url + ' because of a git pull error!')
-                      logger.error(e)
+                      const fetch = spawnSync('git', ['fetch', remote.stdout.toString().trim()], {
+                        shell: false,
+                        cwd: path.resolve(fallbackDependenciesDir + '/' + dependency, '')
+                      })
+                      if (fetch.status !== 0) throw fetch.stderr.toString()
+                      const head = spawnSync('git', ['rev-parse', '--abbrev-ref', `${remote.stdout.toString().trim()}/HEAD`], {
+                        shell: false,
+                        cwd: path.resolve(fallbackDependenciesDir + '/' + dependency, '')
+                      })
+                      const headBranch = head.stdout.toString().trim().replace(remote.stdout.toString().trim() + '/', '')
+                      parts.push('-b', headBranch)
                     }
-                  } else {
-                    const parts = url.split(' ')
-                    if (parts.includes('-b') && fs.readFileSync(fallbackDependenciesDir + '/' + dependency + '/.git/config', 'utf8').includes(parts[0])) {
+                    if (parts.includes('-b')) { // NOTE: only do git pull/checkout if from same repo url and -b is supplied
                       let version = ''
                       for (const key in parts) {
                         const part = parts[key]
@@ -150,18 +152,24 @@ function executeFallbackList (listTypes) {
                           logger.log('Already up to date: ' + fallbackDependenciesDir + '/' + dependency + ' from ' + url + ' is already up to date because the commit\'s git tag matches the desired -b version number.')
                           if (!rerunNpmCi) break // stop checking fallbacks
                         } else { // version supplied is a valid tag, but differs from current tag
-                          const fetch = spawnSync('git', ['fetch', '--tags'], {
-                            shell: false,
-                            cwd: path.resolve(fallbackDependenciesDir + '/' + dependency, '')
-                          })
-                          if (fetch.status !== 0) throw fetch.stderr.toString()
-                          const checkout = spawnSync('git', ['checkout', version], {
-                            shell: false,
-                            cwd: path.resolve(fallbackDependenciesDir + '/' + dependency, '')
-                          })
-                          if (checkout.status !== 0) throw checkout.stderr.toString()
-                          logger.log(`Successfully checked out tag ${version}.`)
-                          updatedDep = true
+                          if (disableReClone) {
+                            const fetch = spawnSync('git', ['fetch', '--tags'], {
+                              shell: false,
+                              cwd: path.resolve(fallbackDependenciesDir + '/' + dependency, '')
+                            })
+                            if (fetch.status !== 0) throw fetch.stderr.toString()
+                            const checkout = spawnSync('git', ['checkout', version], {
+                              shell: false,
+                              cwd: path.resolve(fallbackDependenciesDir + '/' + dependency, '')
+                            })
+                            if (checkout.status !== 0) throw checkout.stderr.toString()
+                            logger.log(`Successfully checked out tag ${version}.`)
+                            updatedDep = true
+                          } else {
+                            logger.log('Removing ' + fallbackDependenciesDir + '/' + dependency + ' from ' + url + ' because the commit\'s git tag differs from the desired -b version number. It will be re-cloned.')
+                            fs.rmSync(path.resolve(fallbackDependenciesDir + '/' + dependency, ''), { recursive: true, force: true })
+                            reClone = true
+                          }
                         }
                       } else { // version supplied is not a tag
                         const remote = spawnSync('git', ['remote'], {
@@ -173,37 +181,68 @@ function executeFallbackList (listTypes) {
                           cwd: path.resolve(fallbackDependenciesDir + '/' + dependency, '')
                         })
                         if (fetch.status !== 0) throw fetch.stderr.toString()
+                        const checkout = spawnSync('git', ['checkout', version], {
+                          shell: false,
+                          cwd: path.resolve(fallbackDependenciesDir + '/' + dependency, '')
+                        })
+                        if (checkout.status !== 0) throw checkout.stderr.toString()
                         const commitsBehind = spawnSync('git', ['rev-list', '--count', `HEAD..${remote.stdout.toString().trim()}/${version}`], {
                           shell: false,
                           cwd: path.resolve(fallbackDependenciesDir + '/' + dependency, '')
                         })
-                        if (commitsBehind.status !== 0) {
-                          const checkout = spawnSync('git', ['checkout', version], {
-                            shell: false,
-                            cwd: path.resolve(fallbackDependenciesDir + '/' + dependency, '')
-                          })
-                          if (checkout.status !== 0) throw checkout.stderr.toString()
-                          logger.log(`Successfully checked out commit ${version}.`)
-                          updatedDep = true
-                        } else if (commitsBehind.stdout.toString() > 0) { // git pull if behind
-                          logger.log('There are new commits available.')
-                          logger.log('Running git pull on ' + fallbackDependenciesDir + '/' + dependency + '...')
-                          const pull = spawnSync('git', ['pull', remote.stdout.toString().trim(), version], {
-                            shell: false,
-                            cwd: path.resolve(fallbackDependenciesDir + '/' + dependency, '')
-                          })
-                          if (pull.status !== 0) throw pull.stderr.toString()
-                          updatedDep = true
-                        } else {
-                          logger.log('Already up to date: ' + fallbackDependenciesDir + '/' + dependency + ' from ' + url + ' is already up to date because the commit\'s branch name matches the desired -b branch name.')
-                          if (!rerunNpmCi) break // stop checking fallbacks
+                        if (commitsBehind.status !== 0) { // commit id was supplied
+                          if (checkout.stderr.toString().toLowerCase().includes('switching')) { // checked out supplied commit id
+                            if (disableReClone) {
+                              logger.log(`Successfully checked out commit ${version}.`)
+                              updatedDep = true
+                            } else {
+                              logger.log('Removing ' + fallbackDependenciesDir + '/' + dependency + ' from ' + url + ' because the commit\'s commit id differs from the desired -b commit id. It will be re-cloned.')
+                              fs.rmSync(path.resolve(fallbackDependenciesDir + '/' + dependency, ''), { recursive: true, force: true })
+                              reClone = true
+                            }
+                          } else { // up to date with supplied commit id
+                            logger.log('Already up to date: ' + fallbackDependenciesDir + '/' + dependency + ' from ' + url + ' is already up to date because the commit\'s commit id matches the desired -b commit id.')
+                            if (!rerunNpmCi) break // stop checking fallbacks
+                          }
+                        } else { // branch name was supplied
+                          if (checkout.stderr.toString().toLowerCase().includes('switched')) {
+                            if (disableReClone) {
+                              logger.log(`Successfully checked out branch ${version}.`)
+                              updatedDep = true
+                            } else {
+                              logger.log('Removing ' + fallbackDependenciesDir + '/' + dependency + ' from ' + url + ' because the commit\'s branch name differs from the desired -b branch name. It will be re-cloned.')
+                              fs.rmSync(path.resolve(fallbackDependenciesDir + '/' + dependency, ''), { recursive: true, force: true })
+                              reClone = true
+                            }
+                          }
+                          if (!reClone) {
+                            if (commitsBehind.stdout.toString() > 0) { // git pull on branch if behind
+                              logger.log('There are new commits available.')
+                              logger.log('Running git pull on ' + fallbackDependenciesDir + '/' + dependency + '...')
+                              const pull = spawnSync('git', ['pull', remote.stdout.toString().trim(), version], {
+                                shell: false,
+                                cwd: path.resolve(fallbackDependenciesDir + '/' + dependency, '')
+                              })
+                              if (pull.status !== 0) throw pull.stderr.toString()
+                              updatedDep = true
+                            } else { // up to date with remote branch
+                              if (!updatedDep) {
+                                logger.log('Already up to date: ' + fallbackDependenciesDir + '/' + dependency + ' from ' + url + ' is already up to date because the commit\'s branch name matches the desired -b branch name and there are no changes to pull.')
+                                if (!rerunNpmCi && !updatedDep) break // stop checking fallbacks
+                              }
+                            }
+                          }
                         }
                       }
-                    } else {
-                      logger.log('Removing ' + fallbackDependenciesDir + '/' + dependency + ' from ' + url + ' because a different git url was supplied. It will be re-cloned.')
+                    } else { // NOTE: same url, but no -b supplied = re-clone
+                      logger.log('Removing ' + fallbackDependenciesDir + '/' + dependency + ' from ' + url + ' because a -b version number, branch name or commit id was not supplied. It will be re-cloned.')
                       fs.rmSync(path.resolve(fallbackDependenciesDir + '/' + dependency, ''), { recursive: true, force: true })
                       reClone = true
                     }
+                  } else { // NOTE: different url supplied = re-clone
+                    logger.log('Removing ' + fallbackDependenciesDir + '/' + dependency + ' from ' + url + ' because a different git url was supplied. It will be re-cloned.')
+                    fs.rmSync(path.resolve(fallbackDependenciesDir + '/' + dependency, ''), { recursive: true, force: true })
+                    reClone = true
                   }
                   if (!reClone && !rerunNpmCi && !updatedDep) continue // try the next fallback
                 }
@@ -230,6 +269,7 @@ function executeFallbackList (listTypes) {
                         break
                       }
                     }
+                    logger.log('Trying now to clone ' + url.split(' ')[0] + ' ' + dependency + ' and then checkout to ' + version + ' because the supplied -b looks to be a specific commit id.')
                     const cloneUrl = spawnSync('git', args, {
                       shell: false,
                       stdio: [0, 1, 2], // display output from git

--- a/fallback-dependencies.js
+++ b/fallback-dependencies.js
@@ -96,7 +96,7 @@ function executeFallbackList (listTypes) {
           for (const i in fallbacks) {
             let url = fallbacks[i]
             const rerunNpmCi = process.env.FALLBACK_DEPENDENCIES_RERUN_NPM_CI || pkg[listType].rerunNpmCi
-            const disableReClone = process.env.FALLBACK_DEPENDENCIES_DISABLE_RECLONE || pkg[listType].disableReClone
+            const enableCheckout = process.env.FALLBACK_DEPENDENCIES_ENABLE_CHECKOUT || pkg[listType].enableCheckout
             let reClone = false
             let updatedDep = false
             let skipDeps = false
@@ -105,14 +105,14 @@ function executeFallbackList (listTypes) {
               skipDeps = true
             }
             try {
-              if (fs.existsSync(fallbackDependenciesDir + '/' + dependency)) { // NOTE: repo dir already exists
+              if (fs.existsSync(fallbackDependenciesDir + '/' + dependency)) {
                 if (!fs.existsSync(fallbackDependenciesDir + '/' + dependency + '/.git/config')) {
                   logger.error('Cannot update ' + fallbackDependenciesDir + '/' + dependency + ' because it does not appear to be a git repo!')
                   break // move on to next dep
                 } else {
                   const parts = url.split(' ')
                   if (fs.readFileSync(fallbackDependenciesDir + '/' + dependency + '/.git/config', 'utf8').includes(parts[0])) { // scan .git/config to check if url supplied exists within it
-                    if (!parts.includes('-b') && disableReClone) { // TODO: add a `&&` for if env var is supplied. adds -b to bare url that points to HEAD
+                    if (!parts.includes('-b') && enableCheckout) { // add -b to url that points to HEAD branch
                       const remote = spawnSync('git', ['remote'], {
                         shell: false,
                         cwd: path.resolve(fallbackDependenciesDir + '/' + dependency, '')
@@ -129,7 +129,7 @@ function executeFallbackList (listTypes) {
                       const headBranch = head.stdout.toString().trim().replace(remote.stdout.toString().trim() + '/', '')
                       parts.push('-b', headBranch)
                     }
-                    if (parts.includes('-b')) { // NOTE: only do git pull/checkout if from same repo url and -b is supplied
+                    if (parts.includes('-b')) {
                       let version = ''
                       for (const key in parts) {
                         const part = parts[key]
@@ -152,7 +152,7 @@ function executeFallbackList (listTypes) {
                           logger.log('Already up to date: ' + fallbackDependenciesDir + '/' + dependency + ' from ' + url + ' is already up to date because the commit\'s git tag matches the desired -b version number.')
                           if (!rerunNpmCi) break // stop checking fallbacks
                         } else { // version supplied is a valid tag, but differs from current tag
-                          if (disableReClone) {
+                          if (enableCheckout) {
                             const fetch = spawnSync('git', ['fetch', '--tags'], {
                               shell: false,
                               cwd: path.resolve(fallbackDependenciesDir + '/' + dependency, '')
@@ -192,7 +192,7 @@ function executeFallbackList (listTypes) {
                         })
                         if (commitsBehind.status !== 0) { // commit id was supplied
                           if (checkout.stderr.toString().toLowerCase().includes('switching')) { // checked out supplied commit id
-                            if (disableReClone) {
+                            if (enableCheckout) {
                               logger.log(`Successfully checked out commit ${version}.`)
                               updatedDep = true
                             } else {
@@ -206,7 +206,7 @@ function executeFallbackList (listTypes) {
                           }
                         } else { // branch name was supplied
                           if (checkout.stderr.toString().toLowerCase().includes('switched')) {
-                            if (disableReClone) {
+                            if (enableCheckout) {
                               logger.log(`Successfully checked out branch ${version}.`)
                               updatedDep = true
                             } else {
@@ -228,23 +228,22 @@ function executeFallbackList (listTypes) {
                             } else { // up to date with remote branch
                               if (!updatedDep) {
                                 logger.log('Already up to date: ' + fallbackDependenciesDir + '/' + dependency + ' from ' + url + ' is already up to date because the commit\'s branch name matches the desired -b branch name and there are no changes to pull.')
-                                if (!rerunNpmCi && !updatedDep) break // stop checking fallbacks
+                                if (!rerunNpmCi) break // stop checking fallbacks
                               }
                             }
                           }
                         }
                       }
-                    } else { // NOTE: same url, but no -b supplied = re-clone
+                    } else {
                       logger.log('Removing ' + fallbackDependenciesDir + '/' + dependency + ' from ' + url + ' because a -b version number, branch name or commit id was not supplied. It will be re-cloned.')
                       fs.rmSync(path.resolve(fallbackDependenciesDir + '/' + dependency, ''), { recursive: true, force: true })
                       reClone = true
                     }
-                  } else { // NOTE: different url supplied = re-clone
+                  } else {
                     logger.log('Removing ' + fallbackDependenciesDir + '/' + dependency + ' from ' + url + ' because a different git url was supplied. It will be re-cloned.')
                     fs.rmSync(path.resolve(fallbackDependenciesDir + '/' + dependency, ''), { recursive: true, force: true })
                     reClone = true
                   }
-                  if (!reClone && !rerunNpmCi && !updatedDep) continue // try the next fallback
                 }
               }
               if (reClone || !fs.existsSync(fallbackDependenciesDir + '/' + dependency)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fallback-dependencies",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fallback-dependencies",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "CC-BY-4.0",
       "dependencies": {
         "roosevelt-logger": "1.0.1"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/fallback-dependencies/graphs/contributors"
     }
   ],
-  "version": "1.1.2",
+  "version": "1.1.3",
   "files": [
     "fallback-dependencies.js",
     "*.md"

--- a/test/test.js
+++ b/test/test.js
@@ -14,7 +14,7 @@ const desiredVersion = path.join(__dirname, './util/desiredVersion.js')
 const domainOverride = path.join(__dirname, './util/domainOverride.js')
 const failedToClone = path.join(__dirname, './util/failedToClone')
 const failedToCloneVersion = path.join(__dirname, './util/failedToCloneVersion')
-const failedToUpdate = path.join(__dirname, './util/failedToUpdate.js')
+// const failedToUpdate = path.join(__dirname, './util/failedToUpdate.js')
 const gitCheckoutTagError = path.join(__dirname, './util/gitCheckoutTagError.js')
 const gitCheckoutCommitError = path.join(__dirname, './util/gitCheckoutCommitError.js')
 const gitCloneCheckoutError = path.join(__dirname, './util/gitCloneCheckoutError.js')
@@ -338,12 +338,12 @@ describe('universal fallback-dependencies tests', () => {
     assert(output.includes('did not match any file(s) known to git'), 'git checkout command didn\'t throw an error')
   })
 
-  it('should throw an error if dependency fails to update', () => {
-    fs.rmSync(path.join(__dirname, './clones'), { recursive: true, force: true })
-    fs.rmSync(path.join(__dirname, './repos'), { recursive: true, force: true })
-    const output = require(failedToUpdate)('fallbackDependencies')
-    assert(output.includes('Cannot update lib/fallback-deps-test-repo-2'), 'lib/fallback-deps-test-repo-2 has been updated')
-  })
+  // it('should throw an error if dependency fails to update', () => {
+  //   fs.rmSync(path.join(__dirname, './clones'), { recursive: true, force: true })
+  //   fs.rmSync(path.join(__dirname, './repos'), { recursive: true, force: true })
+  //   const output = require(failedToUpdate)('fallbackDependencies')
+  //   assert(output.includes('Cannot update lib/fallback-deps-test-repo-2'), 'lib/fallback-deps-test-repo-2 has been updated')
+  // })
 })
 
 describe('fallbackDevDependencies-exclusive tests', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -7,18 +7,18 @@ const appendingDirectOnly = path.join(__dirname, './util/appendingDirectOnly.js'
 const basicFallbackDependencies = path.join(__dirname, './util/basicFallbackDependencies.js')
 const branchUpToDate = path.join(__dirname, './util/branchUpToDate.js')
 const checkoutNonTaggedCommit = path.join(__dirname, './util/checkoutNonTaggedCommit.js')
+const checkoutHeadBranch = path.join(__dirname, './util/checkoutHeadBranch.js')
 const cloningNonTaggedCommit = path.join(__dirname, './util/cloningNonTaggedCommit.js')
 const cloningSpecificGitTag = path.join(__dirname, './util/cloningSpecificGitTag.js')
-const createGitPullError = path.join(__dirname, './util/createGitPullError.js')
 const desiredVersion = path.join(__dirname, './util/desiredVersion.js')
 const domainOverride = path.join(__dirname, './util/domainOverride.js')
 const failedToClone = path.join(__dirname, './util/failedToClone')
 const failedToCloneVersion = path.join(__dirname, './util/failedToCloneVersion')
-// const failedToUpdate = path.join(__dirname, './util/failedToUpdate.js')
 const gitCheckoutTagError = path.join(__dirname, './util/gitCheckoutTagError.js')
 const gitCheckoutCommitError = path.join(__dirname, './util/gitCheckoutCommitError.js')
 const gitCloneCheckoutError = path.join(__dirname, './util/gitCloneCheckoutError.js')
 const gitError = path.join(__dirname, './util/gitError.js')
+const gitFetchHeadError = path.join(__dirname, './util/gitFetchHeadError.js')
 const gitFetchTagsError = path.join(__dirname, './util/gitFetchTagsError.js')
 const gitFetchRemoteError = path.join(__dirname, './util/gitFetchRemoteError.js')
 const gitPullRemoteBranchError = path.join(__dirname, './util/gitPullRemoteBranchError.js')
@@ -28,7 +28,10 @@ const notGitRepo = path.join(__dirname, './util/notGitRepo.js')
 const pullFromBranchName = path.join(__dirname, './util/pullFromBranchName.js')
 const pullFromNonTaggedCommit = path.join(__dirname, './util/pullFromNonTaggedCommit.js')
 const reCloneRepo = path.join(__dirname, './util/reCloneRepo.js')
+const reCloneRepoWithBranch = path.join(__dirname, './util/reCloneRepoWithBranch.js')
+const reCloneRepoWithCommitId = path.join(__dirname, './util/reCloneRepoWithCommitId.js')
 const reposFileInUse = path.join(__dirname, './util/reposFileInUse.js')
+const repoUpToDateWithCommitId = path.join(__dirname, './util/repoUpToDateWithCommitId.js')
 const specificFallbackDependency = path.join(__dirname, './util/specificFallbackDependency.js')
 process.env.FALLBACK_DEPENDENCIES_REMOVE_STALE_DIRECTORIES = true
 
@@ -123,7 +126,21 @@ describe('universal fallback-dependencies tests', () => {
     delete process.env.FALLBACK_DEPENDENCIES_NPM_CI_ARGS // remove env var for remaining tests
   })
 
+  it('should checkout head branch if url supplied doesn\'t specify -b version', () => {
+    process.env.FALLBACK_DEPENDENCIES_ENABLE_CHECKOUT = true
+    const listTypes = ['fallbackDependencies', 'fallbackDevDependencies']
+    while (listTypes.length) {
+      fs.rmSync(path.join(__dirname, './clones'), { recursive: true, force: true })
+      fs.rmSync(path.join(__dirname, './repos'), { recursive: true, force: true })
+      require(checkoutHeadBranch)(listTypes.pop())
+      assert(fs.existsSync(path.join(__dirname, './clones/repo1/lib')), './clones/repo1/lib does not exist')
+      assert(fs.existsSync(path.join(__dirname, './clones/repo1/lib/fallback-deps-test-repo-2')), './clones/repo1/lib/fallback-deps-test-repo-2 does not exist')
+    }
+    delete process.env.FALLBACK_DEPENDENCIES_ENABLE_CHECKOUT
+  })
+
   it('should checkout desired -b version number', () => {
+    process.env.FALLBACK_DEPENDENCIES_ENABLE_CHECKOUT = true
     const listTypes = ['fallbackDependencies', 'fallbackDevDependencies']
     while (listTypes.length) {
       fs.rmSync(path.join(__dirname, './clones'), { recursive: true, force: true })
@@ -133,6 +150,7 @@ describe('universal fallback-dependencies tests', () => {
       assert(fs.existsSync(path.join(__dirname, './clones/repo1/lib/fallback-deps-test-repo-2')), './clones/repo1/lib/fallback-deps-test-repo-2 does not exist')
       assert(fs.existsSync(path.join(__dirname, './clones/repo1/lib/fallback-deps-test-repo-2/.git')), './clones/repo1/lib/fallback-deps-test-repo-2/.git does not exist')
     }
+    delete process.env.FALLBACK_DEPENDENCIES_ENABLE_CHECKOUT
   })
 
   it('should checkout a non-tagged commit', () => {
@@ -145,6 +163,49 @@ describe('universal fallback-dependencies tests', () => {
       assert(fs.existsSync(path.join(__dirname, './clones/repo1/lib/fallback-deps-test-repo-2')), './clones/repo1/lib/fallback-deps-test-repo-2 does not exist')
       assert(fs.existsSync(path.join(__dirname, './clones/repo1/lib/fallback-deps-test-repo-2/.git')), './clones/repo1/lib/fallback-deps-test-repo-2/.git does not exist')
     }
+  })
+
+  it('should reclone repo if desired -b version number differs from current version number', () => {
+    const listTypes = ['fallbackDependencies', 'fallbackDevDependencies']
+    while (listTypes.length) {
+      fs.rmSync(path.join(__dirname, './clones'), { recursive: true, force: true })
+      fs.rmSync(path.join(__dirname, './repos'), { recursive: true, force: true })
+      require(desiredVersion)(listTypes.pop())
+      assert(fs.existsSync(path.join(__dirname, './clones/repo1/lib')), './clones/repo1/lib does not exist')
+      assert(fs.existsSync(path.join(__dirname, './clones/repo1/lib/fallback-deps-test-repo-2')), './clones/repo1/lib/fallback-deps-test-repo-2 does not exist')
+      assert(fs.existsSync(path.join(__dirname, './clones/repo1/lib/fallback-deps-test-repo-2/.git')), './clones/repo1/lib/fallback-deps-test-repo-2/.git does not exist')
+    }
+  })
+
+  it('should reclone repo if -b commit id is supplied', () => {
+    const listTypes = ['fallbackDependencies', 'fallbackDevDependencies']
+    while (listTypes.length) {
+      fs.rmSync(path.join(__dirname, './clones'), { recursive: true, force: true })
+      fs.rmSync(path.join(__dirname, './repos'), { recursive: true, force: true })
+      require(reCloneRepoWithCommitId)(listTypes.pop())
+      assert(fs.existsSync(path.join(__dirname, './clones/repo1/lib')), './clones/repo1/lib does not exist')
+      assert(fs.existsSync(path.join(__dirname, './clones/repo1/lib/fallback-deps-test-repo-2')), './clones/repo1/lib/fallback-deps-test-repo-2 does not exist')
+      assert(fs.existsSync(path.join(__dirname, './clones/repo1/lib/fallback-deps-test-repo-2/.git')), './clones/repo1/lib/fallback-deps-test-repo-2/.git does not exist')
+    }
+  })
+
+  it('should reclone repo if -b branch is supplied', () => {
+    const listTypes = ['fallbackDependencies', 'fallbackDevDependencies']
+    while (listTypes.length) {
+      fs.rmSync(path.join(__dirname, './clones'), { recursive: true, force: true })
+      fs.rmSync(path.join(__dirname, './repos'), { recursive: true, force: true })
+      require(reCloneRepoWithBranch)(listTypes.pop())
+      assert(fs.existsSync(path.join(__dirname, './clones/repo1/lib')), './clones/repo1/lib does not exist')
+      assert(fs.existsSync(path.join(__dirname, './clones/repo1/lib/fallback-deps-test-repo-2')), './clones/repo1/lib/fallback-deps-test-repo-2 does not exist')
+      assert(fs.existsSync(path.join(__dirname, './clones/repo1/lib/fallback-deps-test-repo-2/.git')), './clones/repo1/lib/fallback-deps-test-repo-2/.git does not exist')
+    }
+  })
+
+  it('should reclone repo when attempting to clone specific -b version and url supplied differs from previously cloned repo', () => {
+    fs.rmSync(path.join(__dirname, './clones'), { recursive: true, force: true })
+    fs.rmSync(path.join(__dirname, './repos'), { recursive: true, force: true })
+    const output = require(reCloneRepo)('fallbackDependencies')
+    assert(output.includes('It will be re-cloned'), 'repo was not successfully re-cloned')
   })
 
   it('should pull from a non-tagged commit', () => {
@@ -173,13 +234,6 @@ describe('universal fallback-dependencies tests', () => {
     process.env.FALLBACK_DEPENDENCIES_REMOVE_STALE_DIRECTORIES = true
   })
 
-  it('should re-clone repo when attempting to clone specific -b version and url supplied differs from previously cloned repo', () => {
-    fs.rmSync(path.join(__dirname, './clones'), { recursive: true, force: true })
-    fs.rmSync(path.join(__dirname, './repos'), { recursive: true, force: true })
-    const output = require(reCloneRepo)('fallbackDependencies')
-    assert(output.includes('It will be re-cloned'), 'repo was not successfully re-cloned')
-  })
-
   it('should skip any folder that is not a git repo', () => {
     const listTypes = ['fallbackDependencies', 'fallbackDevDependencies']
     while (listTypes.length) {
@@ -206,7 +260,6 @@ describe('universal fallback-dependencies tests', () => {
       assert(!fs.existsSync(path.join(__dirname, './clones/repo1/lib/fallback-deps-test-repo-2/lib/fallback-deps-test-repo-3/package-lock.json')), './clones/repo1/lib/fallback-deps-test-repo-2/lib/fallback-deps-test-repo-3/package-lock.json does exist')
       assert(!fs.existsSync(path.join(__dirname, './clones/repo1/lib/fallback-deps-test-repo-2/lib/fallback-deps-test-repo-3/package.json')), './clones/repo1/lib/fallback-deps-test-repo-2/lib/fallback-deps-test-repo-3/package.json does exist')
     }
-    delete process.env.FALLBACK_DEPENDENCIES_PREFERRED_WILDCARD
   })
 
   it('should fail to clone fallbacks when supplied url\'s with specific -b versions', () => {
@@ -223,7 +276,14 @@ describe('universal fallback-dependencies tests', () => {
     assert(!fs.existsSync(path.join(__dirname, './clones/repo1/lib/fallback-deps-test-repo-2')), './clones/repo1/lib/fallback-deps-test-repo-2 does exist')
   })
 
-  it('should log that the branch is already up to date', () => {
+  it('should log that the repo is already up to date with the supplied -b commit id', () => {
+    fs.rmSync(path.join(__dirname, './clones'), { recursive: true, force: true })
+    fs.rmSync(path.join(__dirname, './repos'), { recursive: true, force: true })
+    const output = require(repoUpToDateWithCommitId)('fallbackDependencies')
+    assert(output.includes('Already up to date'), 'logs do not indicate that repo is up to date')
+  })
+
+  it('should log that repo is already up to date with the supplied -b branch', () => {
     fs.rmSync(path.join(__dirname, './clones'), { recursive: true, force: true })
     fs.rmSync(path.join(__dirname, './repos'), { recursive: true, force: true })
     const output = require(branchUpToDate)('fallbackDependencies')
@@ -279,16 +339,6 @@ describe('universal fallback-dependencies tests', () => {
     }, 7000)
   })
 
-  it('should throw an error if the "git pull" command fails', () => {
-    const listTypes = ['fallbackDependencies', 'fallbackDevDependencies']
-    while (listTypes.length) {
-      fs.rmSync(path.join(__dirname, './clones'), { recursive: true, force: true })
-      fs.rmSync(path.join(__dirname, './repos'), { recursive: true, force: true })
-      const output = require(createGitPullError)(listTypes.pop())
-      assert(output.includes('git pull error'), 'git pull was successful')
-    }
-  })
-
   it('should throw an error if the "git tag" command fails', () => {
     fs.rmSync(path.join(__dirname, './clones'), { recursive: true, force: true })
     fs.rmSync(path.join(__dirname, './repos'), { recursive: true, force: true })
@@ -310,6 +360,13 @@ describe('universal fallback-dependencies tests', () => {
     assert(output.includes('fatal: this operation must be run in a work tree'), 'git checkout command didn\'t throw an error')
   })
 
+  it('should throw an error if the "git fetch remote" command fails when attempting to search for head branch', () => {
+    fs.rmSync(path.join(__dirname, './clones'), { recursive: true, force: true })
+    fs.rmSync(path.join(__dirname, './repos'), { recursive: true, force: true })
+    const output = require(gitFetchHeadError)('fallbackDependencies')
+    assert(output.includes('fatal: couldn\'t find remote'), 'git fetch command didn\'t throw an error')
+  })
+
   it('should throw an error if the "git fetch remote" command fails', () => {
     fs.rmSync(path.join(__dirname, './clones'), { recursive: true, force: true })
     fs.rmSync(path.join(__dirname, './repos'), { recursive: true, force: true })
@@ -328,7 +385,7 @@ describe('universal fallback-dependencies tests', () => {
     fs.rmSync(path.join(__dirname, './clones'), { recursive: true, force: true })
     fs.rmSync(path.join(__dirname, './repos'), { recursive: true, force: true })
     const output = require(gitPullRemoteBranchError)('fallbackDependencies')
-    assert(output.includes('fatal: this operation must be run in a work tree'), 'git pull remote branch command didn\'t throw an error')
+    assert(output.includes('fatal: Need to specify how to reconcile divergent branches.'), 'git pull remote branch command didn\'t throw an error')
   })
 
   it('should throw an error if the "git checkout version" command fails after a fresh clone', () => {
@@ -337,13 +394,6 @@ describe('universal fallback-dependencies tests', () => {
     const output = require(gitCloneCheckoutError)('fallbackDependencies')
     assert(output.includes('did not match any file(s) known to git'), 'git checkout command didn\'t throw an error')
   })
-
-  // it('should throw an error if dependency fails to update', () => {
-  //   fs.rmSync(path.join(__dirname, './clones'), { recursive: true, force: true })
-  //   fs.rmSync(path.join(__dirname, './repos'), { recursive: true, force: true })
-  //   const output = require(failedToUpdate)('fallbackDependencies')
-  //   assert(output.includes('Cannot update lib/fallback-deps-test-repo-2'), 'lib/fallback-deps-test-repo-2 has been updated')
-  // })
 })
 
 describe('fallbackDevDependencies-exclusive tests', () => {

--- a/test/util/checkoutNonTaggedCommit.js
+++ b/test/util/checkoutNonTaggedCommit.js
@@ -22,7 +22,8 @@ module.exports = (listType) => {
     repo1Package[listType] = {
       dir: 'lib',
       reposFile: 'reposFile.json',
-      npmCiArgs: ['--no-audit', '--silent']
+      npmCiArgs: ['--no-audit', '--silent'],
+      enableCheckout: true
     }
     const repo1PackageLock = {
       name: 'repo1',

--- a/test/util/gitCheckoutTagError.js
+++ b/test/util/gitCheckoutTagError.js
@@ -21,7 +21,8 @@ module.exports = (listType) => {
     }
     repo1Package[listType] = {
       dir: 'lib',
-      reposFile: 'reposFile.json'
+      reposFile: 'reposFile.json',
+      enableCheckout: true
     }
     const repo1PackageLock = {
       name: 'repo1',

--- a/test/util/gitFetchHeadError.js
+++ b/test/util/gitFetchHeadError.js
@@ -116,13 +116,8 @@ module.exports = (listType) => {
       })
     }
 
-    // add 1.0.0 and 1.0.1 tags and attempt to clone repo while specifying 1.0.0
+    // add 1.0.0 tag and attempt to clone repo while specifying it
     spawnSync('git', ['tag', '1.0.0'], {
-      shell: false,
-      stdio: 'pipe', // hide output from git
-      cwd: path.normalize(`${testSrc}/clones/repo2`, '') // where we're cloning the repo to
-    })
-    spawnSync('git', ['tag', '1.0.1'], {
       shell: false,
       stdio: 'pipe', // hide output from git
       cwd: path.normalize(`${testSrc}/clones/repo2`, '') // where we're cloning the repo to
@@ -152,10 +147,9 @@ module.exports = (listType) => {
     }).join('\n')
     fs.writeFileSync(path.normalize(`${testSrc}/clones/repo1/lib/fallback-deps-test-repo-2/.git/config`), updatedConfig)
 
-    // attempt to clone ../../../repos/repo2 -b 1.0.1
     repo1FileData = {
       'fallback-deps-test-repo-2': [
-        '../../../repos/repo2 -b 1.0.1'
+        '../../../repos/repo2'
       ]
     }
     fs.writeFileSync(`${testSrc}/clones/repo1/reposFile.json`, JSON.stringify(repo1FileData))

--- a/test/util/gitFetchRemoteError.js
+++ b/test/util/gitFetchRemoteError.js
@@ -21,7 +21,8 @@ module.exports = (listType) => {
     }
     repo1Package[listType] = {
       dir: 'lib',
-      reposFile: 'reposFile.json'
+      reposFile: 'reposFile.json',
+      enableCheckout: true
     }
     const repo1PackageLock = {
       name: 'repo1',

--- a/test/util/gitPullRemoteBranchError.js
+++ b/test/util/gitPullRemoteBranchError.js
@@ -21,7 +21,8 @@ module.exports = (listType) => {
     }
     repo1Package[listType] = {
       dir: 'lib',
-      reposFile: 'reposFile.json'
+      reposFile: 'reposFile.json',
+      enableCheckout: true
     }
     const repo1PackageLock = {
       name: 'repo1',
@@ -115,19 +116,13 @@ module.exports = (listType) => {
       })
     }
 
-    // add 1.0.0 tag
-    spawnSync('git', ['tag', '1.0.0'], {
+    spawnSync('npm', ['ci'], {
       shell: false,
       stdio: 'pipe', // hide output from git
-      cwd: path.normalize(`${testSrc}/clones/repo2`, '') // where we're cloning the repo to
-    })
-    spawnSync('git', ['push', '--tags'], {
-      shell: false,
-      stdio: 'pipe', // hide output from git
-      cwd: path.normalize(`${testSrc}/clones/repo2`, '') // where we're cloning the repo to
+      cwd: path.normalize(`${testSrc}/clones/repo1`, '') // where we're cloning the repo to
     })
 
-    // push commit to master branch to make 1.0.0 and branch out of sync
+    // push commit to master branch to make branch out of sync
     fs.writeFileSync(`${testSrc}/clones/repo2/commit.txt`, 'this is a commit')
     spawnSync('git', ['add', '.'], {
       shell: false,
@@ -145,26 +140,23 @@ module.exports = (listType) => {
       cwd: path.normalize(`${testSrc}/clones/repo2`, '') // where we're cloning the repo to
     })
 
-    // attempt to clone repo while specifying 1.0.0 tag
-    repo1FileData = {
-      'fallback-deps-test-repo-2': [
-        '../../../repos/repo2 -b 1.0.0'
-      ]
-    }
-    fs.writeFileSync(`${testSrc}/clones/repo1/reposFile.json`, JSON.stringify(repo1FileData))
-    spawnSync('npm', ['ci'], {
+    // push commit to master branch to make branch out of sync
+    fs.writeFileSync(`${testSrc}/clones/repo1/lib/fallback-deps-test-repo-2/commit.txt`, 'this is another commit')
+    spawnSync('git', ['add', '.'], {
       shell: false,
       stdio: 'pipe', // hide output from git
-      cwd: path.normalize(`${testSrc}/clones/repo1`, '') // where we're cloning the repo to
+      cwd: path.normalize(`${testSrc}/clones/repo1/lib/fallback-deps-test-repo-2`, '') // where we're cloning the repo to
     })
-
-    // edit git config to trigger error
-    const config = fs.readFileSync(path.normalize(`${testSrc}/clones/repo1/lib/fallback-deps-test-repo-2/.git/config`)).toString()
-    const updatedConfig = config.split('\n').map(line => {
-      if (line.includes('bare =')) return '\tbare = true'
-      return line
-    }).join('\n')
-    fs.writeFileSync(path.normalize(`${testSrc}/clones/repo1/lib/fallback-deps-test-repo-2/.git/config`), updatedConfig)
+    spawnSync('git', ['commit', '-m', '"commit"'], {
+      shell: false,
+      stdio: 'pipe', // hide output from git
+      cwd: path.normalize(`${testSrc}/clones/repo1/lib/fallback-deps-test-repo-2`, '') // where we're cloning the repo to
+    })
+    spawnSync('git', ['push'], {
+      shell: false,
+      stdio: 'pipe', // hide output from git
+      cwd: path.normalize(`${testSrc}/clones/repo1/lib/fallback-deps-test-repo-2`, '') // where we're cloning the repo to
+    })
 
     // attempt to clone repo while specifying branch name
     repo1FileData = {

--- a/test/util/gitRemoteError.js
+++ b/test/util/gitRemoteError.js
@@ -21,7 +21,8 @@ module.exports = (listType) => {
     }
     repo1Package[listType] = {
       dir: 'lib',
-      reposFile: 'reposFile.json'
+      reposFile: 'reposFile.json',
+      enableCheckout: true
     }
     const repo1PackageLock = {
       name: 'repo1',

--- a/test/util/gitTagError.js
+++ b/test/util/gitTagError.js
@@ -21,7 +21,8 @@ module.exports = (listType) => {
     }
     repo1Package[listType] = {
       dir: 'lib',
-      reposFile: 'reposFile.json'
+      reposFile: 'reposFile.json',
+      enableCheckout: true
     }
     const repo1PackageLock = {
       name: 'repo1',

--- a/test/util/pullFromBranchName.js
+++ b/test/util/pullFromBranchName.js
@@ -23,7 +23,8 @@ module.exports = (listType) => {
       dir: 'lib',
       reposFile: 'reposFile.json',
       preferredWildcard: '../../../repos/repo2',
-      removeStaleDirectories: true
+      removeStaleDirectories: true,
+      enableCheckout: true
     }
     const repo1PackageLock = {
       name: 'repo1',

--- a/test/util/pullFromNonTaggedCommit.js
+++ b/test/util/pullFromNonTaggedCommit.js
@@ -21,7 +21,9 @@ module.exports = (listType) => {
     }
     repo1Package[listType] = {
       dir: 'lib',
-      reposFile: 'reposFile.json'
+      reposFile: 'reposFile.json',
+      preferredWildcard: '../../../repos/repo2',
+      enableCheckout: true
     }
     const repo1PackageLock = {
       name: 'repo1',
@@ -115,19 +117,13 @@ module.exports = (listType) => {
       })
     }
 
-    // add 1.0.0 tag
-    spawnSync('git', ['tag', '1.0.0'], {
+    spawnSync('npm', ['ci'], {
       shell: false,
       stdio: 'pipe', // hide output from git
-      cwd: path.normalize(`${testSrc}/clones/repo2`, '') // where we're cloning the repo to
-    })
-    spawnSync('git', ['push', '--tags'], {
-      shell: false,
-      stdio: 'pipe', // hide output from git
-      cwd: path.normalize(`${testSrc}/clones/repo2`, '') // where we're cloning the repo to
+      cwd: path.normalize(`${testSrc}/clones/repo1`, '') // where we're cloning the repo to
     })
 
-    // push commit to master branch to make 1.0.0 and branch out of sync
+    // push commit to master branch to make branch out of sync
     fs.writeFileSync(`${testSrc}/clones/repo2/commit.txt`, 'this is a commit')
     spawnSync('git', ['add', '.'], {
       shell: false,
@@ -143,19 +139,6 @@ module.exports = (listType) => {
       shell: false,
       stdio: 'pipe', // hide output from git
       cwd: path.normalize(`${testSrc}/clones/repo2`, '') // where we're cloning the repo to
-    })
-
-    // attempt to clone repo while specifying 1.0.0 tag
-    repo1FileData = {
-      'fallback-deps-test-repo-2': [
-        '../../../repos/repo2 -b 1.0.0'
-      ]
-    }
-    fs.writeFileSync(`${testSrc}/clones/repo1/reposFile.json`, JSON.stringify(repo1FileData))
-    spawnSync('npm', ['ci'], {
-      shell: false,
-      stdio: 'pipe', // hide output from git
-      cwd: path.normalize(`${testSrc}/clones/repo1`, '') // where we're cloning the repo to
     })
 
     // attempt to clone repo while specifying branch name

--- a/test/util/reCloneRepoWithBranch.js
+++ b/test/util/reCloneRepoWithBranch.js
@@ -21,8 +21,7 @@ module.exports = (listType) => {
     }
     repo1Package[listType] = {
       dir: 'lib',
-      reposFile: 'reposFile.json',
-      enableCheckout: true
+      reposFile: 'reposFile.json'
     }
     const repo1PackageLock = {
       name: 'repo1',
@@ -116,25 +115,21 @@ module.exports = (listType) => {
       })
     }
 
-    // add 1.0.0 and 1.0.1 tags and attempt to clone repo while specifying 1.0.0
-    spawnSync('git', ['tag', '1.0.0'], {
+    spawnSync('npm', ['ci'], {
       shell: false,
       stdio: 'pipe', // hide output from git
-      cwd: path.normalize(`${testSrc}/clones/repo2`, '') // where we're cloning the repo to
+      cwd: path.normalize(`${testSrc}/clones/repo1`, '') // where we're cloning the repo to
     })
-    spawnSync('git', ['tag', '1.0.1'], {
+
+    // get commit id and attempt to clone repo while specifying it
+    const commit = spawnSync('git', ['log', '--oneline'], {
       shell: false,
       stdio: 'pipe', // hide output from git
-      cwd: path.normalize(`${testSrc}/clones/repo2`, '') // where we're cloning the repo to
-    })
-    spawnSync('git', ['push', '--tags'], {
-      shell: false,
-      stdio: 'pipe', // hide output from git
-      cwd: path.normalize(`${testSrc}/clones/repo2`, '') // where we're cloning the repo to
+      cwd: path.normalize(`${testSrc}/repos/repo2`, '') // where we're cloning the repo to
     })
     repo1FileData = {
       'fallback-deps-test-repo-2': [
-        '../../../repos/repo2 -b 1.0.0'
+        `../../../repos/repo2 -b ${commit.stdout.toString().split(' ')[0].trim()}`
       ]
     }
     fs.writeFileSync(`${testSrc}/clones/repo1/reposFile.json`, JSON.stringify(repo1FileData))
@@ -144,27 +139,16 @@ module.exports = (listType) => {
       cwd: path.normalize(`${testSrc}/clones/repo1`, '') // where we're cloning the repo to
     })
 
-    // edit git config to trigger error
-    const config = fs.readFileSync(path.normalize(`${testSrc}/clones/repo1/lib/fallback-deps-test-repo-2/.git/config`)).toString()
-    const updatedConfig = config.split('\n').map(line => {
-      if (line.includes('fetch =')) return '\tfetch = not-valid'
-      return line
-    }).join('\n')
-    fs.writeFileSync(path.normalize(`${testSrc}/clones/repo1/lib/fallback-deps-test-repo-2/.git/config`), updatedConfig)
-
-    // attempt to clone ../../../repos/repo2 -b 1.0.1
     repo1FileData = {
       'fallback-deps-test-repo-2': [
-        '../../../repos/repo2 -b 1.0.1'
+        '../../../repos/repo2 -b master'
       ]
     }
     fs.writeFileSync(`${testSrc}/clones/repo1/reposFile.json`, JSON.stringify(repo1FileData))
-    const output = spawnSync('npm', ['ci'], {
+    spawnSync('npm', ['ci'], {
       shell: false,
       stdio: 'pipe', // hide output from git
       cwd: path.normalize(`${testSrc}/clones/repo1`, '') // where we're cloning the repo to
     })
-
-    return output.stderr.toString()
   } catch {}
 }


### PR DESCRIPTION
- Added option to enable checking out rather than recloning when changing versions via `FALLBACK_DEPENDENCIES_ENABLE_CHECKOUT` environment variable or `enableCheckout` in `fallbackDependencies` package.json config.